### PR TITLE
Search using 'union' keywords and metadata schemas retrieval

### DIFF
--- a/data-catalog-api/server/service/src/main/java/org/apache/airavata/datacatalog/api/service/DataCatalogAPIService.java
+++ b/data-catalog-api/server/service/src/main/java/org/apache/airavata/datacatalog/api/service/DataCatalogAPIService.java
@@ -36,6 +36,8 @@ import org.apache.airavata.datacatalog.api.MetadataSchemaFieldUpdateRequest;
 import org.apache.airavata.datacatalog.api.MetadataSchemaFieldUpdateResponse;
 import org.apache.airavata.datacatalog.api.MetadataSchemaGetRequest;
 import org.apache.airavata.datacatalog.api.MetadataSchemaGetResponse;
+import org.apache.airavata.datacatalog.api.MetadataSchemaListRequest;
+import org.apache.airavata.datacatalog.api.MetadataSchemaListResponse;
 import org.apache.airavata.datacatalog.api.Permission;
 import org.apache.airavata.datacatalog.api.UserInfo;
 import org.apache.airavata.datacatalog.api.exception.EntityNotFoundException;
@@ -217,6 +219,14 @@ public class DataCatalogAPIService extends DataCatalogAPIServiceGrpc.DataCatalog
         } catch (EntityNotFoundException e) {
             responseObserver.onError(Status.NOT_FOUND.asException());
         }
+    }
+
+    @Override
+    public void getMetadataSchemas(MetadataSchemaListRequest request,
+                                    StreamObserver<MetadataSchemaListResponse> responseObserver) {
+        List<MetadataSchema> fields = dataCatalogService.getMetadataSchemas();
+        responseObserver.onNext(MetadataSchemaListResponse.newBuilder().addAllMetadataSchemas(fields).build());
+        responseObserver.onCompleted();
     }
 
     @Override

--- a/data-catalog-api/server/service/src/main/java/org/apache/airavata/datacatalog/api/service/DataCatalogService.java
+++ b/data-catalog-api/server/service/src/main/java/org/apache/airavata/datacatalog/api/service/DataCatalogService.java
@@ -28,6 +28,8 @@ public interface DataCatalogService {
 
     MetadataSchema getMetadataSchema(String schemaName);
 
+    List<MetadataSchema> getMetadataSchemas();
+
     MetadataSchema createMetadataSchema(MetadataSchema metadataSchema);
 
     MetadataSchemaField getMetadataSchemaField(String schemaName, String fieldName);

--- a/data-catalog-api/server/service/src/main/java/org/apache/airavata/datacatalog/api/service/impl/DataCatalogServiceImpl.java
+++ b/data-catalog-api/server/service/src/main/java/org/apache/airavata/datacatalog/api/service/impl/DataCatalogServiceImpl.java
@@ -143,6 +143,13 @@ public class DataCatalogServiceImpl implements DataCatalogService {
     }
 
     @Override
+    public List<MetadataSchema> getMetadataSchemas() {
+        return metadataSchemaRepository.findAll().stream()
+                .map(this::toMetadataSchema)
+                .toList();
+    }
+
+    @Override
     public MetadataSchema createMetadataSchema(MetadataSchema metadataSchema) {
 
         MetadataSchemaEntity metadataSchemaEntity = new MetadataSchemaEntity();

--- a/data-catalog-api/stubs/src/main/proto/DataCatalogAPI.proto
+++ b/data-catalog-api/stubs/src/main/proto/DataCatalogAPI.proto
@@ -142,6 +142,12 @@ message MetadataSchemaGetRequest {
 message MetadataSchemaGetResponse {
     MetadataSchema metadata_schema = 1;
 }
+message MetadataSchemaListRequest {
+    UserInfo user_info = 1;
+}
+message MetadataSchemaListResponse {
+    repeated MetadataSchema metadata_schemas = 1;
+}
 message MetadataSchemaCreateRequest {
     UserInfo user_info = 1;
     MetadataSchema metadata_schema = 2;
@@ -199,6 +205,7 @@ service DataCatalogAPIService {
     rpc getMetadataSchema(MetadataSchemaGetRequest) returns (MetadataSchemaGetResponse){}
     rpc createMetadataSchema(MetadataSchemaCreateRequest) returns (MetadataSchemaCreateResponse){}
     rpc deleteMetadataSchema(MetadataSchemaDeleteRequest) returns (MetadataSchemaDeleteResponse){}
+    rpc getMetadataSchemas(MetadataSchemaListRequest) returns (MetadataSchemaListResponse){}
     rpc getMetadataSchemaField(MetadataSchemaFieldGetRequest) returns (MetadataSchemaFieldGetResponse){}
     rpc createMetadataSchemaField(MetadataSchemaFieldCreateRequest) returns (MetadataSchemaFieldCreateResponse){}
     rpc updateMetadataSchemaField(MetadataSchemaFieldUpdateRequest) returns (MetadataSchemaFieldUpdateResponse){}


### PR DESCRIPTION
Two main functionalities
- The ability to search in multiple schemas using 'union' and 'union all' keywords. For example: SELECT data_product_id FROM exp_schema UNION SELECT data_product_id FROM my_schema
- Get all the Metadata schemas

Requirement
In the SMILES project, schemas will be used to differentiate product types (computational, experimental, and literature). Each product type can have multiple schemas, identified by a prefix added to the schema name. 
To load data products belonging to a given type the above two functionalities can be used